### PR TITLE
Allow react v17 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "peerDependencies": {
     "@material-ui/core": "^4.0.0",
-    "react": "^16.8.0"
+    "react": "^16.8.0 || ^17.0.0"
   },
   "scripts": {
     "storybook": "start-storybook -p 6006",


### PR DESCRIPTION
### Why

This pull request to allow react 17 as peer dependency. This version of react should ([in theory](https://reactjs.org/blog/2020/10/20/react-v17.html#other-breaking-changes)) not break anything. At work we are currently on react 17, we've had no issue related to it and we are on the latest version of [mdi-material-ui](https://github.com/TeamWertarbyte/mdi-material-ui).

Material-ui now allows react v17 as peer dependency https://github.com/mui-org/material-ui/pull/23697