### PR TITLE
Change the React import to be pedantically correct

### DIFF
--- a/src/util/createIcon.js
+++ b/src/util/createIcon.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import SvgIcon from '@material-ui/core/SvgIcon'
 
 export default (path) => {


### PR DESCRIPTION
I'm bundling a react application, using snowpack during development and ES modules wherever I possibly can. One thing that bumped my head, was why `mdi-material-ui` icons would crash my application in development, whilst `@material-ui/icons` icons would not. After delving deep into it, it's definitely an issue on snowpack's side (not understanding the default import in this case to be syntactically equivalent to a `* as` one), but given that `@material-ui/icons` worked flawlessly, I don't think it'd hurt to update a line to mirror functionality akin to what `@material-ui/icons` does.

[This post](https://github.com/lydell/blog/issues/4) explains the difference between the import statements better than I can. In short, babel is treating `import React from "react"` as a default import (essentially, meaning an import with a named import `default`) whereas [react has no default export](https://github.com/facebook/react/blob/master/packages/react/index.js#L39-L88), just a bunch of named imports, so doing `import * as React from "react"` will group all named imports into a single object which can behave similarly to what's needed.

[`@material-ui/core/utils/createSvgIcon`](https://github.com/mui-org/material-ui/blob/next/packages/material-ui/src/utils/createSvgIcon.js#L1) performs this, and thus it worked fine.