### PR TITLE
Fix material-ui peer dependency on legacy version

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "xml2js": "^0.4.19"
   },
   "peerDependencies": {
-    "material-ui": "^0.20.2 || ^1.0.0-beta.1",
+    "material-ui": "0.x",
     "react": "^16.3.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "xml2js": "^0.4.19"
   },
   "peerDependencies": {
-    "material-ui": "^0.17.4 || ^1.0.0-beta.1",
+    "material-ui": "^0.20.2 || ^1.0.0-beta.1",
     "react": "^16.3.0"
   },
   "scripts": {


### PR DESCRIPTION
Hello,

The last stable version of Material UI V0 is :

```
    "material-ui": "^0.20.2",
```

I made this PR because, with the last version of NPM, it blocks the npm install when using Dockerhub node 15 image (on CI) : 
```
Could not resolve dependency:
npm ERR! peer material-ui@"^0.17.4 || ^1.0.0-beta.1" from mdi-material-ui@4.33.1
npm ERR! node_modules/mdi-material-ui
npm ERR!   mdi-material-ui@"^4.33.1" from the root project
```

I will also fix the following message for all these users that use the legacy version as we are ...

```
npm i
[...]
npm WARN mdi-material-ui@4.33.1 requires a peer of material-ui@^0.17.4 || ^1.0.0-beta.1 but none is installed. You must install peer dependencies yourself.
```
