### PR TITLE
React 18 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
       },
       "peerDependencies": {
         "@mui/material": "^5.0.0 || ^5.0.0-rc.0",
-        "react": "^16.8.0 || ^17.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "peerDependencies": {
     "@mui/material": "^5.0.0 || ^5.0.0-rc.0",
-    "react": "^16.8.0 || ^17.0.0"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
   "scripts": {
     "storybook": "start-storybook -p 6006",


### PR DESCRIPTION
Fix https://github.com/TeamWertarbyte/mdi-material-ui/issues/48

Adding React 18 to the peer dependency, No change is required in the codebase, as it just works with React 18.